### PR TITLE
fix(Now): Removed alias configuration from Now

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,9 +1,6 @@
 {
     "version": 2,
     "name": "ts-react-seed-app",
-    "alias": [
-        "seed.com"
-    ],
     "builds": [
         {
             "src": "package.json",


### PR DESCRIPTION
## Why is this needed?
<!-- brief description of why this change is needed. -->
To allow `master` to be able correctly.

## What changed?
<!-- brief description of what changed. -->
Removed alias from now
