### PR TITLE
chore: add frozen-lockfile to yarnrc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
             - uses: actions/checkout@v3
             - name: Install dependencies, test and build
               run: |
-                  yarn --frozen-lockfile
+                  yarn
                   yarn test
                   yarn build
 

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+install.--frozen-lockfile true


### PR DESCRIPTION
## Why is this needed?
<!-- brief description of why this change is needed. -->
To ensure yarn installs the proper dependencies when deploying.

## What changed?
<!-- brief description of what changed. -->
Added yarnrc.
